### PR TITLE
Add unprotected endpoints

### DIFF
--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -58,7 +58,7 @@ func (s *service) Close() error {
 }
 
 func (s *service) UnprotectedEndpoints() []string {
-	return []string{}
+	return []string{"/cs3.ocm.invite.v1beta1.InviteAPI/AcceptInvite"}
 }
 
 func (s *service) Register(ss *grpc.Server) {

--- a/internal/http/services/ocmd/ocmd.go
+++ b/internal/http/services/ocmd/ocmd.go
@@ -82,7 +82,7 @@ func (s *svc) Prefix() string {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{}
+	return []string{"/invites/accept"}
 }
 
 func (s *svc) Handler() http.Handler {


### PR DESCRIPTION
Note: There's something missing, but I'm not sure how to fix it. 
```
ERR Users/lolu/cern/lovisaFork/reva/internal/http/interceptors/providerauthorizer/providerauthorizer.go:106 > error searching for the user error="rpc error: code = Unknown desc = gateway: error calling GetUser: rpc error: code = Unauthenticated desc = auth: core access token not found"
```