### PR TITLE
do not duplicate base

### DIFF
--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -1642,9 +1642,8 @@ func (s *svc) listSharesFolder(ctx context.Context) (*provider.ListContainerResp
 				continue
 			}
 		}
-
-		base := path.Base(ref.Path)
-		info.Path = path.Join(ref.GetPath(), base)
+		
+		info.Path = ref.GetPath()
 		lcr.Infos[i] = info
 	}
 


### PR DESCRIPTION
without this I am seeing `/remote.php/dav/files/einstein/Shares/from marie/from marie/` in the webdav api at the ocdav endpoint.

@ishank011 @labkode ... is this because you are working on ocm?